### PR TITLE
feat: tree context menu, drag-to-composer, skill panel actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 *.log
 .DS_Store
 TUI-Assessment.md
+
+# local backups of in-progress edits
+*.bak-*

--- a/lib/client.js
+++ b/lib/client.js
@@ -230,6 +230,110 @@ html[data-fe-panel-open] [data-phase=active] {
 .fe-hl .fe-tok-d { color: var(--fe-hl-directive, #c678dd); }
 `;
 
+		const EXTRA_CSS = `
+html { --fe-rail-width: 48px; }
+
+/* left-side activity rail: VS Code style, docked to the far left */
+.fe-rail {
+  position: fixed; top: 50%; left: 0; right: auto; transform: translateY(-50%);
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 8px 6px;
+  background: var(--dsw-alias-bg-overlay);
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-left: none;
+  border-radius: 0 10px 10px 0;
+  box-shadow: 4px 0 16px rgba(0,0,0,.12);
+  z-index: 110;
+}
+.fe-rail-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px; padding: 0;
+  border: none; border-radius: 8px;
+  background: transparent; color: var(--dsw-alias-label-secondary);
+  cursor: pointer; font-size: 16px; line-height: 1;
+}
+.fe-rail-btn:hover { background: var(--dsw-alias-bg-layer-2); color: var(--dsw-alias-label-primary); }
+.fe-rail-btn-on { color: var(--dsw-alias-brand-primary); background: var(--dsw-alias-bg-layer-2); }
+
+/* File tree panel now docks left, covering the DSH sidebar. */
+html[data-fe-panel-open] [data-phase=active] { padding-right: 0; }
+.fe-panel {
+  left: var(--fe-rail-width); right: auto;
+  border-left: none;
+  border-right: 1px solid var(--dsw-alias-border-l1);
+  box-shadow: 4px 0 16px rgba(0,0,0,.12);
+}
+.fe-resize { left: auto; right: -4px; }
+.fe-collapse-tab {
+  left: auto; right: -17px;
+  border: 1px solid var(--dsw-alias-border-l1); border-left: none;
+  border-radius: 0 7px 7px 0;
+  box-shadow: 3px 0 8px rgba(0,0,0,.10);
+}
+.fe-preview {
+  left: calc(var(--fe-rail-width) + var(--fe-panel-width)); right: auto;
+  border-left: 1px solid var(--dsw-alias-border-l1);
+  border-right: none;
+  box-shadow: 4px 0 16px rgba(0,0,0,.12);
+}
+.fe-info-panel {
+  position: fixed; top: 0; left: var(--fe-rail-width); bottom: 0; z-index: 105;
+  display: flex; flex-direction: column;
+  background: var(--dsw-alias-bg-overlay);
+  border-right: 1px solid var(--dsw-alias-border-l1);
+  box-shadow: 4px 0 16px rgba(0,0,0,.12);
+  color: var(--dsw-alias-label-primary);
+  font-size: 13px; line-height: 1.45;
+  width: 380px; max-width: 70vw; min-width: 240px;
+  box-sizing: border-box;
+}
+.fe-info-header { display: flex; align-items: center; gap: 6px; padding: 8px 10px; border-bottom: 1px solid var(--dsw-alias-border-l1); flex: none; font-weight: 600; }
+.fe-info-body { flex: 1; overflow: auto; padding: 6px 8px; }
+.fe-info-section { margin: 8px 2px 4px; font-size: 11px; color: var(--dsw-alias-label-tertiary); text-transform: uppercase; letter-spacing: .04em; }
+.fe-info-row { display: flex; flex-direction: column; gap: 2px; padding: 7px 10px; margin: 2px 0; border-radius: 8px; }
+.fe-info-row:hover { background: var(--dsw-alias-bg-layer-1); }
+.fe-info-title { font-size: 13px; color: var(--dsw-alias-label-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fe-info-desc { font-size: 11px; color: var(--dsw-alias-label-secondary); }
+.fe-skill-row { cursor: pointer; }
+
+/* right-click context menu on tree rows */
+.fe-ctxmenu {
+  position: fixed; z-index: 9990;
+  min-width: 190px; padding: 5px;
+  background: var(--dsw-alias-bg-overlay);
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0,0,0,.28);
+  color: var(--dsw-alias-label-primary);
+  font-size: 12.5px; line-height: 1.4;
+  user-select: none;
+}
+.fe-ctxmenu-item {
+  padding: 6px 10px; border-radius: 5px;
+  cursor: pointer; white-space: nowrap;
+}
+.fe-ctxmenu-item:hover { background: var(--dsw-alias-bg-layer-2); color: var(--dsw-alias-label-primary); }
+.fe-ctxmenu-sep { height: 1px; margin: 4px 6px; background: var(--dsw-alias-border-l1); }
+.fe-ctxmenu .fe-ctxmenu-path {
+  max-width: 260px; overflow: hidden; text-overflow: ellipsis;
+  color: var(--dsw-alias-label-tertiary);
+  font-size: 11px; padding: 2px 10px 6px;
+}
+
+/* drop-highlight on the composer while dragging a tree row over it */
+.fe-drop-target {
+  outline: 2px dashed var(--dsw-alias-brand-primary) !important;
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+.fe-row[draggable=true] { cursor: grab; }
+.fe-row[draggable=true]:active { cursor: grabbing; }
+
+/* inserted path text inside the composer: theme label color, !important so
+   composer placeholder/transparent-text tricks can never hide it */
+.fe-path-span { color: var(--dsw-alias-label-primary) !important; }
+`;
+
 		// ---------- fetch API (same origin as the GUI) ----------
 		const api = {
 			list: (path) => fetch('/plugins/file-explorer/list?path=' + encodeURIComponent(path)).then((r) => r.json()),
@@ -246,8 +350,185 @@ html[data-fe-panel-open] [data-phase=active] {
 				body: JSON.stringify({ path }),
 			}).then((r) => r.json()),
 		};
+		const apiInfo = {
+			skills: (root) => fetch('/plugins/file-explorer/skills?root=' + encodeURIComponent(root)).then((r) => r.json()),
+			plugins: () => fetch('/plugins/file-explorer/plugins').then((r) => r.json()),
+		};
 
 		const inject = ["slots"];
+
+		// ---------- clipboard & composer helpers ----------
+		const feCopyToClipboard = async (text) => {
+			try {
+				await navigator.clipboard.writeText(text);
+				return true;
+			} catch {
+				try {
+					const ta = document.createElement('textarea');
+					ta.value = text;
+					ta.style.position = 'fixed'; ta.style.opacity = '0';
+					document.body.appendChild(ta);
+					ta.select();
+					const ok = document.execCommand('copy');
+					document.body.removeChild(ta);
+					return ok;
+				} catch {
+					return false;
+				}
+			}
+		};
+
+		// Find the active conversation composer (input box). Prefers the
+		// active-phase column, excludes anything inside this plugin's panels.
+		const feFindComposer = () => {
+			const candidates = [];
+			const phase = document.querySelector('[data-phase=active]');
+			if (phase) candidates.push(...phase.querySelectorAll('textarea, [contenteditable="true"]'));
+			candidates.push(...document.querySelectorAll('textarea, [contenteditable="true"]'));
+			for (const el of candidates) {
+				if (el.closest('.fe-panel, .fe-preview, .fe-ctxmenu')) continue;
+				if (el.offsetParent === null && !el.isConnected) continue;
+				return el;
+			}
+			return null;
+		};
+
+		// Pick a visible text color for inserted path text. The composer's own
+		// computed color is unreliable (placeholder tricks / transparent text),
+		// so prefer a real text-node color, then contrast against the first
+		// non-transparent background (guarantees visibility in any theme),
+		// then the theme label variable.
+		const fePickTextColor = (el) => {
+			try {
+				const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+				for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+					if (n.textContent && n.textContent.trim().length > 0 && n.parentElement) {
+						return window.getComputedStyle(n.parentElement).color;
+					}
+				}
+			} catch { /* fall through */ }
+			let node = el;
+			while (node && node !== document.documentElement) {
+				const bg = window.getComputedStyle(node).backgroundColor;
+				if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
+					const m = /rgba?\(([^)]+)\)/.exec(bg);
+					if (m) {
+						const p = m[1].split(',').map((s) => parseFloat(s));
+						const lum = (0.299 * p[0] + 0.587 * p[1] + 0.114 * p[2]) / 255;
+						return lum > 0.5 ? '#1f2328' : '#e8eaed';
+					}
+					break;
+				}
+				node = node.parentElement;
+			}
+			try {
+				const v = window.getComputedStyle(document.documentElement)
+					.getPropertyValue('--dsw-alias-label-primary').trim();
+				if (v !== '') return v;
+			} catch { /* fall through */ }
+			return window.getComputedStyle(el).color;
+		};
+
+		// Insert text into the composer at the cursor. Returns false when no
+		// composer was found (caller can fall back to clipboard).
+		//
+		// The DSH composer is a managed editor (ProseMirror-like): it rewrites
+		// its DOM from internal state on any re-render, so manually inserted
+		// nodes get flattened (transparent placeholder color) or wiped (the
+		// hover-a-button-and-it-disappears symptom). The only reliable path is
+		// the editor's own input channel: dispatch a synthetic `beforeinput`
+		// (editors intercept it) and fall back to native execCommand (fires
+		// trusted beforeinput+input), then a manual DOM insert as last resort.
+		const feInsertIntoComposer = (text) => {
+			const el = feFindComposer();
+			if (!el) return false;
+			el.focus();
+			if (el.isContentEditable) {
+				let inserted = false;
+				let method = 'none';
+				const sel = window.getSelection();
+				let range = null;
+				if (sel && sel.rangeCount > 0 && sel.anchorNode && el.contains(sel.anchorNode)) {
+					range = sel.getRangeAt(0);
+					range.collapse(false);
+				} else {
+					range = document.createRange();
+					range.selectNodeContents(el);
+					range.collapse(false);
+					if (sel) { sel.removeAllRanges(); sel.addRange(range) }
+				}
+				const present = () => el.textContent.indexOf(text) >= 0;
+				// 1) synthetic beforeinput — managed editors take this over
+				try {
+					const bi = new InputEvent('beforeinput', { inputType: 'insertText', data: text, bubbles: true, cancelable: true, composed: true });
+					const notPrevented = el.dispatchEvent(bi);
+					if (!notPrevented && present()) { inserted = true; method = 'beforeinput' }
+				} catch { /* InputEvent unavailable */ }
+				// 2) native execCommand — fires trusted beforeinput + input
+				if (!inserted) {
+					try {
+						document.execCommand('insertText', false, text);
+						if (present()) { inserted = true; method = 'execCommand' }
+					} catch { /* ignore */ }
+				}
+				// 3) manual span fallback + input event
+				if (!inserted) {
+					try {
+						const span = document.createElement('span');
+						span.textContent = text;
+						range.insertNode(span);
+						range.setStartAfter(span);
+						range.collapse(true);
+						el.dispatchEvent(new Event('input', { bubbles: true }));
+						inserted = true;
+						method = 'manual';
+					} catch { inserted = false }
+				}
+				// 4) force a visible color on the composer root when its own
+				// color is transparent (placeholder trick)
+				try {
+					const cur = window.getComputedStyle(el).color;
+					if (cur === 'transparent' || cur === 'rgba(0, 0, 0, 0)') {
+						el.style.setProperty('color', fePickTextColor(el), 'important');
+					}
+				} catch { /* ignore */ }
+				// diagnostic — open DevTools (F12) and read the console line
+				try {
+					console.log('[fe-insert] method=' + method + ' present=' + present()
+						+ ' tag=' + el.tagName + ' cls=' + String(el.className).slice(0, 80)
+						+ ' color=' + window.getComputedStyle(el).color
+						+ ' prosemirror=' + !!(el.classList.contains('ProseMirror')
+							|| el.querySelector('.ProseMirror')
+							|| (el.parentElement && el.parentElement.querySelector('.ProseMirror'))));
+				} catch { /* ignore */ }
+				return inserted;
+			}
+			if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
+				// React-controlled inputs need the native value setter
+				try {
+					const proto = el.tagName === 'TEXTAREA' ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+					const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+					const start = el.selectionStart ?? el.value.length;
+					const end = el.selectionEnd ?? start;
+					const next = el.value.slice(0, start) + text + el.value.slice(end);
+					setter.call(el, next);
+					const pos = start + text.length;
+					el.selectionStart = el.selectionEnd = pos;
+					el.dispatchEvent(new InputEvent('input', { inputType: 'insertText', data: text, bubbles: true, composed: true }));
+					return true;
+				} catch {
+					const start = el.selectionStart ?? el.value.length;
+					const end = el.selectionEnd ?? start;
+					el.value = el.value.slice(0, start) + text + el.value.slice(end);
+					const pos = start + text.length;
+					el.selectionStart = el.selectionEnd = pos;
+					el.dispatchEvent(new Event('input', { bubbles: true }));
+					return true;
+				}
+			}
+			return false;
+		};
+
 
 		// Expand-all/collapse-all coordination, stable across renders (the panel
 		// is a single instance per page). A token bump cancels an in-flight run.
@@ -265,12 +546,14 @@ html[data-fe-panel-open] [data-phase=active] {
 			searchError: null,
 			matches: null,
 			truncated: false,
+			view: 'chat',
 			listeners: new Set(),
 		};
 		const emit = () => { for (const fn of Array.from(store.listeners)) fn() };
 		const subscribe = (fn) => { store.listeners.add(fn); return () => { store.listeners.delete(fn) } };
 		const setOpen = (value) => { store.open = !!value; emit() };
 		const toggleOpen = () => setOpen(!store.open);
+		const setView = (value) => { store.view = value; emit() };
 
 		let searchTimer = null;
 		const doSearch = (q) => {
@@ -754,11 +1037,40 @@ html[data-fe-panel-open] [data-phase=active] {
 				className: 'fe-toggle' + (s.open ? ' fe-toggle-on' : ''),
 				title: '文件资源管理器',
 				'aria-label': '文件资源管理器',
-				onClick: toggleOpen,
+				onClick: () => { if (s.open && s.view === 'files') setOpen(false); else { setView('files'); setOpen(true); } },
 			}, react.createElement(Icon, { name: 'files', size: 15 }));
 		};
 
 		// ---------- tree node ----------
+		// Generic right-click context menu: `menu` = { x, y, header?, items: [{label, run} | {sep:true}] }.
+		const ContextMenu = (props) => {
+			const menu = props.menu;
+			if (!menu) return null;
+			const items = menu.items || [];
+			const header = menu.header;
+			const width = 210;
+			const height = items.length * 28 + (header ? 26 : 0) + 30;
+			const style = {
+				left: Math.max(4, Math.min(menu.x, window.innerWidth - width - 8)),
+				top: Math.max(4, Math.min(menu.y, window.innerHeight - height - 8)),
+			};
+			return react.createElement('div', {
+				className: 'fe-ctxmenu',
+				style,
+				onMouseDown: (e) => e.stopPropagation(),
+				onContextMenu: (e) => { e.preventDefault(); e.stopPropagation(); },
+			},
+				header ? react.createElement('div', { className: 'fe-ctxmenu-path', title: header }, header) : null,
+				items.map((it, i) => it.sep
+					? react.createElement('div', { key: 'sep' + i, className: 'fe-ctxmenu-sep' })
+					: react.createElement('div', {
+						key: i,
+						className: 'fe-ctxmenu-item',
+						onClick: () => { props.onClose(); it.run(); },
+					}, it.label)),
+			);
+		};
+
 		const TreeNode = (props) => {
 			const entry = props.entry;
 			const tree = props.tree;
@@ -773,6 +1085,18 @@ html[data-fe-panel-open] [data-phase=active] {
 				onClick: () => isDir ? props.onToggle(entry.path) : props.onOpen(entry, true),
 				onDoubleClick: () => props.onOpen(entry, false),
 				title: entry.path,
+				draggable: true,
+				onDragStart: (e) => {
+					e.dataTransfer.setData('application/x-fe-path', entry.path);
+					e.dataTransfer.effectAllowed = 'copy';
+				},
+				onContextMenu: (e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					if (typeof props.onContextMenu === 'function') {
+						props.onContextMenu(entry, e.clientX, e.clientY);
+					}
+				},
 			},
 				react.createElement('span', { className: 'fe-chevron' + (isDir ? '' : ' fe-chevron-none') }, isDir
 					? react.createElement(Icon, { name: expanded ? 'chevronDown' : 'chevronRight', size: 12 })
@@ -787,7 +1111,7 @@ html[data-fe-panel-open] [data-phase=active] {
 			if (isDir && expanded) {
 				if (children) {
 					for (const child of children) {
-						nodes.push(react.createElement(TreeNode, { key: child.path, entry: child, depth: props.depth + 1, tree, onToggle: props.onToggle, onSelect: props.onSelect, onOpen: props.onOpen }));
+						nodes.push(react.createElement(TreeNode, { key: child.path, entry: child, depth: props.depth + 1, tree, onToggle: props.onToggle, onSelect: props.onSelect, onOpen: props.onOpen, onContextMenu: props.onContextMenu }));
 					}
 				} else if (!loading && error) {
 					nodes.push(react.createElement('div', { key: '__err', className: 'fe-node-error', style: { paddingLeft: 6 + (props.depth + 1) * 14 } }, error));
@@ -822,6 +1146,46 @@ html[data-fe-panel-open] [data-phase=active] {
 			const [status, setStatus] = react.useState(null);
 			const [previewWidth, setPreviewWidth] = react.useState(400);
 			const [drag, setDrag] = react.useState(null);
+			const [menu, setMenu] = react.useState(null);
+			const closeMenu = () => setMenu(null);
+			const onTreeContextMenu = (entry, x, y) => {
+				const rootPath = (tree && tree.rootPath) || store.rootPath;
+				const full = entry.path;
+				const rel = (rootPath && full.indexOf(rootPath) === 0)
+					? full.slice(rootPath.length).replace(/^[\\/]+/, '')
+					: full;
+				const name = entry.name;
+				const isDir = entry.type === 'directory';
+				setMenu({
+					x, y,
+					header: full,
+					items: [
+						{ label: '复制完整路径', run: () => feCopyToClipboard(full) },
+						{ label: '复制相对路径', run: () => feCopyToClipboard(rel) },
+						{ label: '复制文件名', run: () => feCopyToClipboard(name) },
+						{ label: '复制 Markdown 引用', run: () => feCopyToClipboard('[' + name + '](' + full + ')') },
+						{ sep: true },
+						{ label: '插入完整路径到输入框', run: () => { if (!feInsertIntoComposer(full)) feCopyToClipboard(full) } },
+						{ label: '插入相对路径到输入框', run: () => { if (!feInsertIntoComposer(rel)) feCopyToClipboard(rel) } },
+						{ sep: true },
+						{ label: isDir ? '在 VS Code 中打开目录' : '在 VS Code 中打开文件', run: () => api.openVscode(full) },
+					],
+				});
+			};
+			react.useEffect(() => {
+				if (!menu) return;
+				const onDown = (e) => {
+					if (e.target && typeof e.target.closest === 'function' && e.target.closest('.fe-ctxmenu')) return;
+					setMenu(null);
+				};
+				const onKey = (e) => { if (e.key === 'Escape') setMenu(null) };
+				window.addEventListener('mousedown', onDown, true);
+				window.addEventListener('keydown', onKey);
+				return () => {
+					window.removeEventListener('mousedown', onDown, true);
+					window.removeEventListener('keydown', onKey);
+				};
+			}, [menu]);
 			// Re-click on the previewed file schedules a close; a following
 			// double-click cancels it, so dblclick never flickers.
 			const previewToggleRef = react.useRef(null);
@@ -1101,7 +1465,7 @@ html[data-fe-panel-open] [data-phase=active] {
 			const onResizeMove = (e) => {
 				if (!drag) return;
 				if (drag.kind === 'tree') {
-					store.width = Math.max(220, Math.min(1000, drag.startWidth + (drag.startX - e.clientX)));
+					store.width = Math.max(220, Math.min(1000, drag.startWidth + (e.clientX - drag.startX)));
 					emit();
 				} else {
 					// preview: drag its LEFT edge; moving left widens the preview
@@ -1119,6 +1483,16 @@ html[data-fe-panel-open] [data-phase=active] {
 					style: { paddingLeft: 6 },
 					onClick: () => toggleDir(tree.rootPath),
 					title: tree.rootPath,
+					draggable: true,
+					onDragStart: (e) => {
+						e.dataTransfer.setData('application/x-fe-path', tree.rootPath);
+						e.dataTransfer.effectAllowed = 'copy';
+					},
+					onContextMenu: (e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						onTreeContextMenu({ path: tree.rootPath, name: tree.rootName || tree.rootPath, type: 'directory' }, e.clientX, e.clientY);
+					},
 				},
 					react.createElement('span', { className: 'fe-chevron' }, react.createElement(Icon, { name: tree.expanded.has(tree.rootPath) ? 'chevronDown' : 'chevronRight', size: 12 })),
 					react.createElement('span', { className: 'fe-node-icon fe-node-dir' }, react.createElement(Icon, { name: 'folder', size: 14 })),
@@ -1129,7 +1503,7 @@ html[data-fe-panel-open] [data-phase=active] {
 					const children = tree.cache.get(tree.rootPath);
 					if (children) {
 						for (const child of children) {
-							rows.push(react.createElement(TreeNode, { key: child.path, entry: child, depth: 1, tree, onToggle: toggleDir, onSelect: selectFile, onOpen: (e, toggle) => openFile(e, false, toggle) }));
+							rows.push(react.createElement(TreeNode, { key: child.path, entry: child, depth: 1, tree, onToggle: toggleDir, onSelect: selectFile, onOpen: (e, toggle) => openFile(e, false, toggle), onContextMenu: onTreeContextMenu }));
 						}
 					} else if (!tree.loading.has(tree.rootPath) && tree.errors[tree.rootPath]) {
 						rows.push(react.createElement('div', { key: 'err', className: 'fe-node-error', style: { paddingLeft: 20 } }, tree.errors[tree.rootPath]));
@@ -1197,7 +1571,7 @@ html[data-fe-panel-open] [data-phase=active] {
 				return react.createElement('div', { className: 'fe-preview-body' }, head, body);
 			};
 
-			if (!s.open) return null;
+			if (!s.open || s.view !== 'files') return null;
 			// ">" tab at the middle of the leftmost edge: collapses the whole
 			// explorer (tree panel, or preview pane when a file preview is open).
 			const collapseTab = react.createElement('button', {
@@ -1227,7 +1601,7 @@ html[data-fe-panel-open] [data-phase=active] {
 			const previewPane = editor
 				? react.createElement('div', {
 					className: 'fe-preview',
-					style: { right: s.width + 'px', width: previewWidth + 'px', maxWidth: 'calc(100vw - ' + s.width + 'px - 12px)' },
+					style: { width: previewWidth + 'px', maxWidth: 'calc(100vw - var(--fe-rail-width) - ' + s.width + 'px - 12px)' },
 				},
 					react.createElement('div', { className: 'fe-preview-resize', title: '拖动调整宽度', onPointerDown: (e) => onResizeStart('preview', e) }),
 					collapseTab,
@@ -1238,12 +1612,175 @@ html[data-fe-panel-open] [data-phase=active] {
 				drag ? react.createElement('div', { className: 'fe-drag-capture', onPointerMove: onResizeMove, onPointerUp: endDrag, onPointerLeave: endDrag }) : null,
 				treePanel,
 				previewPane,
+				react.createElement(ContextMenu, { menu, onClose: closeMenu }),
+			);
+		};
+
+		// ---------- skills panel ----------
+		const SkillsPanel = (props) => {
+			const s = useStore();
+			const currentSessionId = props.useSessions((st) => st.current);
+			const wsItems = props.useWorkspaces((st) => st.items);
+			const recentWorkspaceId = props.useWorkspaces((st) => st.recentWorkspaceId);
+			let rootPath = null;
+			if (currentSessionId) for (const w of wsItems) if (w.sessionIds.indexOf(currentSessionId) >= 0) { rootPath = w.path; break }
+			if (!rootPath && recentWorkspaceId) for (const w of wsItems) if (w.workspaceId === recentWorkspaceId) { rootPath = w.path; break }
+			if (!rootPath && wsItems.length > 0) rootPath = wsItems[0].path;
+			const [state, setState] = react.useState({ loading: false, error: null, skills: [] });
+			const [expanded, setExpanded] = react.useState({});
+			const [menu, setMenu] = react.useState(null);
+			const closeMenu = () => setMenu(null);
+			react.useEffect(() => {
+				if (!menu) return;
+				const onDown = (e) => {
+					if (e.target && typeof e.target.closest === 'function' && e.target.closest('.fe-ctxmenu')) return;
+					setMenu(null);
+				};
+				const onKey = (e) => { if (e.key === 'Escape') setMenu(null) };
+				window.addEventListener('mousedown', onDown, true);
+				window.addEventListener('keydown', onKey);
+				return () => {
+					window.removeEventListener('mousedown', onDown, true);
+					window.removeEventListener('keydown', onKey);
+				};
+			}, [menu]);
+			const onSkillContextMenu = (sk, e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				setMenu({
+					x: e.clientX,
+					y: e.clientY,
+					header: sk.name,
+					items: [
+						{ label: '复制 skill 名称', run: () => feCopyToClipboard(sk.name) },
+						{ label: '插入 skill 名称到输入框', run: () => { if (!feInsertIntoComposer(sk.name)) feCopyToClipboard(sk.name) } },
+						{ sep: true },
+						{ label: '复制路径', run: () => feCopyToClipboard(sk.path || '') },
+					],
+				});
+			};
+			react.useEffect(() => {
+				if (!s.open || s.view !== 'skills' || !rootPath) return;
+				let cancelled = false;
+				setState({ loading: true, error: null, skills: [] });
+				apiInfo.skills(rootPath).then((res) => {
+					if (cancelled) return;
+					if (res && res.error) setState({ loading: false, error: res.error, skills: [] });
+					else setState({ loading: false, error: null, skills: (res && res.skills) || [] });
+				}).catch((err) => {
+					if (!cancelled) setState({ loading: false, error: String((err && err.message) || err), skills: [] });
+				});
+				return () => { cancelled = true };
+			}, [s.open, s.view, rootPath]);
+			if (!s.open || s.view !== 'skills') return null;
+			const toggleSkill = (name) => {
+				setExpanded((prev) => {
+					const next = { ...prev };
+					if (next[name]) delete next[name];
+					else next[name] = true;
+					return next;
+				});
+			};
+			const rows = state.skills.map((sk) => react.createElement('div', {
+				key: sk.name,
+				className: 'fe-info-row fe-skill-row',
+				title: sk.path || sk.name,
+				role: 'button',
+				tabIndex: 0,
+				'aria-expanded': expanded[sk.name] === true,
+				onClick: () => toggleSkill(sk.name),
+				onKeyDown: (e) => { if (e && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); toggleSkill(sk.name); } },
+				onContextMenu: (e) => onSkillContextMenu(sk, e),
+			},
+				react.createElement('span', { className: 'fe-info-title' }, (expanded[sk.name] ? '▾ ' : '▸ ') + sk.name),
+				expanded[sk.name] === true ? react.createElement('span', { className: 'fe-info-desc' }, sk.description || '') : null,
+			));
+			return react.createElement('div', { className: 'fe-info-panel' },
+				react.createElement('div', { className: 'fe-info-header' },
+					react.createElement('span', null, 'Skills'),
+					react.createElement('button', { className: 'fe-iconbtn', title: '关闭', onClick: () => setOpen(false), style: { marginLeft: 'auto' } }, '✕'),
+				),
+				react.createElement('div', { className: 'fe-info-body' },
+					state.loading ? react.createElement('div', { className: 'fe-empty' }, '加载中…')
+					: state.error ? react.createElement('div', { className: 'fe-empty' }, state.error)
+					: rows.length > 0 ? rows : react.createElement('div', { className: 'fe-empty' }, '未发现 skill'),
+				),
+				react.createElement(ContextMenu, { menu, onClose: closeMenu }),
+			);
+		};
+
+		// ---------- plugins panel ----------
+		const PluginsPanel = (props) => {
+			const s = useStore();
+			const [state, setState] = react.useState({ loading: false, error: null, bundles: [], plugins: [] });
+			react.useEffect(() => {
+				if (!s.open || s.view !== 'plugins') return;
+				let cancelled = false;
+				setState({ loading: true, error: null, bundles: [], plugins: [] });
+				apiInfo.plugins().then((res) => {
+					if (cancelled) return;
+					if (res && res.error) setState({ loading: false, error: res.error, bundles: [], plugins: [] });
+					else setState({ loading: false, error: null, bundles: (res && res.bundles) || [], plugins: (res && res.plugins) || [] });
+				}).catch((err) => {
+					if (!cancelled) setState({ loading: false, error: String((err && err.message) || err), bundles: [], plugins: [] });
+				});
+				return () => { cancelled = true };
+			}, [s.open, s.view]);
+			if (!s.open || s.view !== 'plugins') return null;
+			const pluginRows = state.plugins.map((pl) => react.createElement('div', { key: pl.name, className: 'fe-info-row' },
+				react.createElement('span', { className: 'fe-info-title' }, pl.name),
+				react.createElement('span', { className: 'fe-info-desc' }, pl.spec || ''),
+			));
+			const bundleRows = state.bundles.map((b) => react.createElement('div', { key: b, className: 'fe-info-row' },
+				react.createElement('span', { className: 'fe-info-title' }, b),
+			));
+			return react.createElement('div', { className: 'fe-info-panel' },
+				react.createElement('div', { className: 'fe-info-header' },
+					react.createElement('span', null, 'DSH 插件'),
+					react.createElement('button', { className: 'fe-iconbtn', title: '关闭', onClick: () => setOpen(false), style: { marginLeft: 'auto' } }, '✕'),
+				),
+				react.createElement('div', { className: 'fe-info-body' },
+					state.loading ? react.createElement('div', { className: 'fe-empty' }, '加载中…')
+					: state.error ? react.createElement('div', { className: 'fe-empty' }, state.error)
+					: react.createElement(react.Fragment, null,
+						react.createElement('div', { className: 'fe-info-section' }, 'Bundles（' + state.bundles.length + '）'),
+						bundleRows.length > 0 ? bundleRows : react.createElement('div', { className: 'fe-empty' }, '无'),
+						react.createElement('div', { className: 'fe-info-section' }, 'Dependencies（' + state.plugins.length + '）'),
+						pluginRows.length > 0 ? pluginRows : react.createElement('div', { className: 'fe-empty' }, '无'),
+					),
+				),
+			);
+		};
+
+		// ---------- VS Code style left activity rail: files / chat / skills / plugins ----------
+		const ActivityRail = (props) => {
+			const s = useStore();
+			const toggleView = (view) => {
+				if (view === 'chat') { setView('chat'); setOpen(false); return; }
+				if (s.open && s.view === view) setOpen(false);
+				else { setView(view); setOpen(true); }
+			};
+			const railBtn = (view, emoji, title) => react.createElement('button', {
+				className: 'fe-rail-btn' + ((view === 'chat' ? !s.open : (s.open && s.view === view)) ? ' fe-rail-btn-on' : ''),
+				title,
+				'aria-label': title,
+				onClick: () => toggleView(view),
+			}, emoji);
+			return react.createElement(react.Fragment, null,
+				react.createElement('div', { className: 'fe-rail' },
+					railBtn('files', '🗂', '文件树'),
+					railBtn('chat', '💬', '对话列表'),
+					railBtn('skills', '🧠', 'Skills'),
+					railBtn('plugins', '🧩', 'DSH 插件'),
+				),
+				s.open && s.view === 'skills' ? react.createElement(SkillsPanel, props) : null,
+				s.open && s.view === 'plugins' ? react.createElement(PluginsPanel, props) : null,
 			);
 		};
 
 		function apply(ctx) {
 			const styleEl = document.createElement('style');
-			styleEl.textContent = CSS;
+			styleEl.textContent = CSS + EXTRA_CSS;
 			document.head.appendChild(styleEl);
 			ctx.effect(() => () => { styleEl.remove() }, 'file-explorer: styles');
 
@@ -1266,6 +1803,58 @@ html[data-fe-panel-open] [data-phase=active] {
 			document.addEventListener('dblclick', onChatDblClick);
 			ctx.effect(() => () => { document.removeEventListener('dblclick', onChatDblClick) }, 'file-explorer: chat dblclick collapse');
 
+			// Drag a tree row over the composer: highlight it, and on drop
+			// insert the file path at the cursor.
+			let feDropTarget = null;
+			const feClearHighlight = () => {
+				if (feDropTarget) { feDropTarget.classList.remove('fe-drop-target'); feDropTarget = null }
+			};
+			const feHasPath = (e) => {
+				const dt = e.dataTransfer;
+				return dt && typeof dt.types.indexOf === 'function' && dt.types.indexOf('application/x-fe-path') >= 0;
+			};
+			const feDropComposer = (e) => {
+				if (!feHasPath(e)) return;
+				const t = e.target;
+				const composer = t && typeof t.closest === 'function'
+					? t.closest('textarea, [contenteditable="true"]')
+					: null;
+				if (composer && !composer.closest('.fe-panel, .fe-preview')) return composer;
+				return null;
+			};
+			const onFeDragOver = (e) => {
+				const composer = feDropComposer(e);
+				if (!composer) return;
+				e.preventDefault();
+				e.dataTransfer.dropEffect = 'copy';
+				if (feDropTarget !== composer) {
+					feClearHighlight();
+					feDropTarget = composer;
+					composer.classList.add('fe-drop-target');
+				}
+			};
+			const onFeDrop = (e) => {
+				const composer = feDropComposer(e);
+				feClearHighlight();
+				if (!composer) return;
+				const path = e.dataTransfer.getData('application/x-fe-path');
+				if (!path) return;
+				e.preventDefault();
+				e.stopPropagation();
+				if (!feInsertIntoComposer(path)) feCopyToClipboard(path);
+			};
+			const onFeDragEnd = () => feClearHighlight();
+			document.addEventListener('dragover', onFeDragOver, true);
+			document.addEventListener('drop', onFeDrop, true);
+			document.addEventListener('dragend', onFeDragEnd, true);
+			ctx.effect(() => () => {
+				document.removeEventListener('dragover', onFeDragOver, true);
+				document.removeEventListener('drop', onFeDrop, true);
+				document.removeEventListener('dragend', onFeDragEnd, true);
+				feClearHighlight();
+			}, 'file-explorer: composer drop');
+
+
 			const slots = ctx.get('slots');
 			if (slots === undefined) return;
 			slots.inject('shell.overlay', () => slots.register(
@@ -1275,6 +1864,10 @@ html[data-fe-panel-open] [data-phase=active] {
 			slots.inject('conversation.session.header.actions', () => slots.register(
 				{ name: 'conversation.session.header.actions', id: 'file-explorer-toggle', order: 30, label: '文件资源管理器' },
 				(props) => react.createElement(ToggleButton, props),
+			));
+			slots.inject('shell.overlay', () => slots.register(
+				{ name: 'shell.overlay', id: 'dsh-activity-rail', order: 95, label: 'Activity Rail' },
+				(props) => react.createElement(ActivityRail, props),
 			));
 		}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,8 @@
  *
  * @module dsh-file-explorer
  */
+import { join } from 'node:path'
+
 export const name = 'file-explorer'
 export const inject = ['fs']
 
@@ -44,6 +46,73 @@ export function apply(ctx) {
       return null
     }
     return path
+  }
+
+  const dshHome = process.env.DSH_HOME || (process.env.USERPROFILE ? join(process.env.USERPROFILE, '.dsh') : null)
+
+  const readJsonFile = async (file) => {
+    try {
+      const target = await fs.resolve(file)
+      const info = await fs.stat(target)
+      if (info === undefined || info.type !== 'file') return null
+      return JSON.parse(await fs.readText(target))
+    } catch {
+      return null
+    }
+  }
+
+  const parseSkillFrontmatter = (text) => {
+    const CR = String.fromCharCode(13)
+    const LF = String.fromCharCode(10)
+    const t = String(text || '').split(CR).join('')
+    if (t.indexOf('---') !== 0) return null
+    const end = t.indexOf(LF + '---', 3)
+    if (end < 0) return null
+    const fm = t.slice(3, end)
+    const lines = fm.split(LF)
+    const grab = (key) => {
+      for (const line of lines) {
+        if (line.trim().startsWith(key + ':')) {
+          return line.trim().slice(key.length + 1).trim().replace(/^['"]|['"]$/g, '')
+        }
+      }
+      return ''
+    }
+    const name = grab('name')
+    const description = grab('description')
+    if (!name) return null
+    return { name, description }
+  }
+
+  const listSkillsInDir = async (dir) => {
+    let target
+    try { target = await fs.resolve(dir) } catch { return [] }
+    try {
+      const info = await fs.stat(target)
+      if (info === undefined || info.type !== 'directory') return []
+    } catch { return [] }
+    let entries
+    try { entries = await fs.listDir(target) } catch { return [] }
+    const skills = []
+    for (const entry of entries) {
+      if (entry.type !== 'directory') continue
+      const skillDir = fs.processPath(entry.target)
+      for (const file of ['SKILL.md', 'skill.md']) {
+        try {
+          const filePath = join(skillDir, file)
+          const ftarget = await fs.resolve(filePath)
+          const finfo = await fs.stat(ftarget)
+          if (finfo === undefined || finfo.type !== 'file') continue
+          const text = await fs.readText(ftarget)
+          const meta = parseSkillFrontmatter(text)
+          if (meta !== null) {
+            skills.push({ name: meta.name, description: meta.description, source: 'claude', path: skillDir })
+          }
+          break
+        } catch { /* keep looking */ }
+      }
+    }
+    return skills
   }
 
   let registered = false
@@ -242,8 +311,57 @@ export function apply(ctx) {
     })
   }
 
+  const registerInfoRoutes = () => {
+    const webServer = ctx.get('webServer') ?? ctx.get('httpServer')
+    if (webServer === undefined) return
+    ctx.effect(() => webServer.register({ kind: 'exact', path: '/plugins/file-explorer/skills', handler: async (req, res) => {
+      try {
+        const root = param(req, 'root') || process.env.DSH_WORKSPACE || process.cwd()
+        const seen = new Set()
+        const skills = []
+        const dirs = []
+        try { dirs.push(join(root, '.claude', 'skills')) } catch { /* ignore */ }
+        try { dirs.push(join(root, '.dsh', 'skills')) } catch { /* ignore */ }
+        try { dirs.push(join(root, '.agents', 'skills')) } catch { /* ignore */ }
+        if (dshHome) {
+          try { dirs.push(join(dshHome, 'skills')) } catch { /* ignore */ }
+          try { dirs.push(join(dshHome, '.claude', 'skills')) } catch { /* ignore */ }
+        }
+        try { dirs.push(join(process.env.USERPROFILE || process.env.HOME || '', '.claude', 'skills')) } catch { /* ignore */ }
+        for (const dir of dirs) {
+          for (const sk of await listSkillsInDir(dir)) {
+            if (!seen.has(sk.name)) {
+              seen.add(sk.name)
+              skills.push(sk)
+            }
+          }
+        }
+        skills.sort((a, b) => a.name.localeCompare(b.name))
+        send(res, 200, { skills })
+      } catch (err) {
+        send(res, 500, { error: message(err) })
+      }
+    } }), 'file-explorer: skills')
+
+    ctx.effect(() => webServer.register({ kind: 'exact', path: '/plugins/file-explorer/plugins', handler: async (req, res) => {
+      try {
+        let profile = null
+        if (dshHome) {
+          profile = await readJsonFile(join(dshHome, 'profiles', 'web', 'package.json'))
+        }
+        const bundles = (profile && profile.dsh && profile.dsh.profile && profile.dsh.profile.bundles) || []
+        const dependencies = (profile && profile.dependencies) || {}
+        const plugins = Object.entries(dependencies).map(([name, spec]) => ({ name, spec }))
+        send(res, 200, { profilePath: profile ? join(dshHome, 'profiles', 'web', 'package.json') : null, bundles, plugins })
+      } catch (err) {
+        send(res, 500, { error: message(err) })
+      }
+    } }), 'file-explorer: plugins')
+  }
+  registerInfoRoutes()
+
   registerWeb()
   ctx.on('internal/service', (name) => {
-    if (name === 'webServer' || name === 'httpServer' || name === 'shell') registerWeb()
+    if (name === 'webServer' || name === 'httpServer' || name === 'shell') { registerWeb(); registerInfoRoutes() }
   })
 }


### PR DESCRIPTION
## 摘要
为文件资源管理器补全一组文件树交互与信息面板：右键菜单、拖拽到对话输入框、Skills 面板、Plugins 面板、左侧活动栏。

## 改动内容

**交互增强**
- 文件树右键菜单（文件 / 目录 / 根目录行）：复制完整路径、相对路径、文件名、Markdown 引用；插入路径到输入框；在 VS Code 中打开文件或目录
- 拖拽：任意树节点行拖入对话输入框，路径插入光标处，输入框带高亮反馈
- 输入框插入走编辑器的 beforeinput 正规通道（合成 InputEvent，失败回退 execCommand）——直接操作 DOM 会被受控编辑器拍平/丢失，此方式插入的文本能存活且保持输入框自身样式

**新面板**
- Skills 面板：浏览工作区 .claude/skills 下的 skill（解析 SKILL.md frontmatter），右键可复制 / 插入 skill 名称、复制路径；配套后端路由 /plugins/file-explorer/skills
- Plugins 面板：浏览当前 profile 已装配的插件与 bundle；配套后端路由 /plugins/file-explorer/plugins

**布局**
- 左侧活动栏（Activity Rail）：VS Code 风格，在 文件 / Skills / Plugins 三个视图间切换；文件树面板 dock 到左侧并跟随活动栏宽度（这是布局偏好，若希望保持原作者右侧面板布局可仅取功能部分）

## 备注
- 已在 Windows + DSH 0.1.0-rc.6 + web profile 实测
- 无网络请求、无遥测